### PR TITLE
fix(notif): fix error when creating a notification

### DIFF
--- a/lib/plex/controller.dart
+++ b/lib/plex/controller.dart
@@ -82,7 +82,8 @@ class PlexController implements Controller {
   Future<void> _sendNotification(Map _notif, [String filename]) async {
     var notif = Notification(_notif);
     if ((notif.event.contains('media') && args['media'] == false) ||
-        (notif.event.contains('library') && args['library'] == false)) {
+        (notif.event.contains('library') && args['library'] == false) ||
+        notif.metadata == null) {
       return;
     }
     var str = notif.fmt();

--- a/lib/plex/models/Notification.dart
+++ b/lib/plex/models/Notification.dart
@@ -18,10 +18,10 @@ class Notification {
     event = notif['event'];
     user = notif['user'];
     owner = notif['owner'];
-    account = Account(notif['Account']);
-    server = Server(notif['Server']);
-    player = Player(notif['Player']);
-    metadata = Metadata(notif['Metadata']);
+    account = notif['Account'] != null ? Account(notif['Account']) : null;
+    server = notif['Server'] != null ? Server(notif['Server']) : null;
+    player = notif['Player'] != null ? Player(notif['Player']) : null;
+    metadata = notif['Metadata'] != null ? Metadata(notif['Metadata']) : null;
   }
 
   Embed fmt() {


### PR DESCRIPTION
I'm not sure how to reproduce the error since it's when Plex
doesn't send the metadata (the show was not found on thetvdb.com ?)

An easy fix it to skip the notification sending when the medatada
is null. It doesn't impact the end user since a notification without
info is useless anyway.

Closes #2